### PR TITLE
fix(aspect_ratio_mapping): use width/height attributes instead of inline style

### DIFF
--- a/files/en-us/web/media/images/aspect_ratio_mapping/index.html
+++ b/files/en-us/web/media/images/aspect_ratio_mapping/index.html
@@ -20,7 +20,7 @@ tags:
 
 <p>In the olden days of web development, it was always seen as a good practice to add <code>width</code> and <code>height</code> attributes to your HTML {{htmlelement("img")}} elements, so that when browsers first loaded the page, they could put a correctly-sized placeholder box in the layout for each image to appear in when it finally loads.</p>
 
-<p><img alt="Two screenshots the first without an image but with space reserved, the second showing the image loaded into the reserved space." src="https://mdn.mozillademos.org/files/16945/ar-guide.jpg" style="height: 857px; width: 1200px;"></p>
+<p><img alt="Two screenshots the first without an image but with space reserved, the second showing the image loaded into the reserved space." src="https://mdn.mozillademos.org/files/16945/ar-guide.jpg" width="1200" height="857"></p>
 
 <p>Without the <code>width</code> and <code>height</code> attributes, no placeholder space would be created, and when the image finally loaded you would get a noticeable jank in the page layout. This wasn't an attractive thing for your users to see, and could also result in performance issues due to the repainting required after each image loads, hence adding the attributes being a good idea.</p>
 


### PR DESCRIPTION
this fixes the image stretching and also adopts the guidance in the article.

currently the image is stretched vertically:

![Screenshot: part of the aspect ratio mapping article](https://user-images.githubusercontent.com/413984/102973839-d8a75300-4540-11eb-90eb-260e7f5c48ad.png)

the stylesheet has `img { height: auto }` but it's overwritten by the inline style set to the img element.