### PR TITLE
fix(jsref-global-math): fix descriptions of `Math.log` and `Math.log1p`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/math/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/index.md
@@ -82,21 +82,9 @@ Unlike many other global objects, `Math` is not a constructor. All properties an
 - {{jsxref("Global_Objects/Math/imul", "Math.imul(<var>x</var>, <var>y</var>)")}}
   - : Returns the result of the 32-bit integer multiplication of `x` and `y`.
 - {{jsxref("Global_Objects/Math/log", "Math.log(<var>x</var>)")}}
-
-  - : Returns the natural logarithm (㏒
-
-    <sub>e</sub>
-
-    ; also, ㏑) of `x`.
-
+  - : Returns the natural logarithm (㏒<sub>e</sub>; also, ㏑) of `x`.
 - {{jsxref("Global_Objects/Math/log1p", "Math.log1p(<var>x</var>)")}}
-
-  - : Returns the natural logarithm (㏒
-
-    <sub>e</sub>
-
-    ; also ㏑) of `1 + x` for the number `x`.
-
+  - : Returns the natural logarithm (㏒<sub>e</sub>; also ㏑) of `1 + x` for the number `x`.
 - {{jsxref("Global_Objects/Math/log10", "Math.log10(<var>x</var>)")}}
   - : Returns the base-10 logarithm of `x`.
 - {{jsxref("Global_Objects/Math/log2", "Math.log2(<var>x</var>)")}}


### PR DESCRIPTION
> Issue number that this PR fixes (if any). For example: 'Fixes #987654321'

N/A

> What was wrong/why is this fix needed? (quick summary only)

it looks broken.

![screenshot: showing `math.log()` and `math.log1p()` in the math global object page ](https://user-images.githubusercontent.com/413984/133120449-bbad5403-01fe-49f0-8733-a0ee5d71c500.png)

This fixes unintended line breakings before and after the log bases `<sub>e</sub>`.

> Anything else that could help us review it

not sure. somebody who done the markup conversion could review if keeping the `<sub>` is okay or not.
