### PR TITLE
Firefox 94 notes: fix typo (`layout()` → `layer()`)

### DIFF
--- a/files/en-us/mozilla/firefox/releases/94/index.md
+++ b/files/en-us/mozilla/firefox/releases/94/index.md
@@ -19,7 +19,7 @@ No notable changes
 
 ### CSS
 
-- The [`@import`](/en-US/docs/Web/CSS/@import) rule now supports the `layout()` function, which specifies a cascade layer defined using the [`@layer`](/en-US/docs/Web/CSS/@layer) rule ({{bug(1699217)}}).
+- The [`@import`](/en-US/docs/Web/CSS/@import) rule now supports the `layer()` function, which specifies a cascade layer defined using the [`@layer`](/en-US/docs/Web/CSS/@layer) rule ({{bug(1699217)}}).
 
 ### JavaScript
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

fix the name of the Cascade Layers function in the `@import` rule in the Firefox 94 dev notes.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

https://github.com/mdn/content/blob/5371aa06d8c63471dad058105dbc6da4eccd701a/files/en-us/mozilla/firefox/releases/94/index.md?plain=1#L20-L22

the name of the function is `layer()` not `layout()`.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

- [CSS Cascading and Inheritance Level 5](https://www.w3.org/TR/css-cascade-5/#at-import)
- [1699217 - Add support for layer() option to @import](https://bugzilla.mozilla.org/show_bug.cgi?id=1699217)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
